### PR TITLE
Add GitHub report viewer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -10,6 +12,13 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AInewsMakerFetcher" />
+        android:theme="@style/Theme.AInewsMakerFetcher">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -1,0 +1,99 @@
+package com.spymag.ainewsmakerfetcher
+
+import android.app.DatePickerDialog
+import android.os.Bundle
+import android.widget.Button
+import android.widget.ListView
+import androidx.appcompat.app.AppCompatActivity
+import org.json.JSONArray
+import java.net.HttpURLConnection
+import java.net.URL
+import java.time.LocalDate
+import java.util.Calendar
+import kotlin.concurrent.thread
+
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var listView: ListView
+    private lateinit var adapter: ReportAdapter
+
+    private val allReports = mutableListOf<Report>()
+    private var fromDate: LocalDate? = null
+    private var toDate: LocalDate? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        listView = findViewById(R.id.listReports)
+        adapter = ReportAdapter(this, mutableListOf())
+        listView.adapter = adapter
+
+        findViewById<Button>(R.id.btnRefresh).setOnClickListener { fetchReports() }
+        findViewById<Button>(R.id.btnClearFilter).setOnClickListener {
+            fromDate = null
+            toDate = null
+            applyFilter()
+        }
+        findViewById<Button>(R.id.btnFromDate).setOnClickListener { pickDate { date ->
+            fromDate = date
+            applyFilter()
+        } }
+        findViewById<Button>(R.id.btnToDate).setOnClickListener { pickDate { date ->
+            toDate = date
+            applyFilter()
+        } }
+
+        fetchReports()
+    }
+
+    private fun fetchReports() {
+        thread {
+            try {
+                val url = URL("https://api.github.com/repos/spymag/AInewsMaker/contents/reports")
+                val conn = url.openConnection() as HttpURLConnection
+                conn.connect()
+                val json = conn.inputStream.bufferedReader().use { it.readText() }
+                val fetched = parseReports(json)
+                allReports.clear()
+                allReports.addAll(fetched)
+                runOnUiThread { applyFilter() }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    private fun parseReports(json: String): List<Report> {
+        val arr = JSONArray(json)
+        val list = mutableListOf<Report>()
+        val dateRegex = Regex("(\\d{4}-\\d{2}-\\d{2})")
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            val name = obj.getString("name")
+            if (name.endsWith(".md")) {
+                val url = obj.getString("download_url")
+                val match = dateRegex.find(name)
+                val date = match?.let { LocalDate.parse(it.value) } ?: LocalDate.MIN
+                list.add(Report(name, date, url))
+            }
+        }
+        return list.sortedByDescending { it.date }
+    }
+
+    private fun applyFilter() {
+        val filtered = allReports.filter { report ->
+            val afterFrom = fromDate?.let { !report.date.isBefore(it) } ?: true
+            val beforeTo = toDate?.let { !report.date.isAfter(it) } ?: true
+            afterFrom && beforeTo
+        }
+        adapter.update(filtered)
+    }
+
+    private fun pickDate(onDate: (LocalDate) -> Unit) {
+        val now = Calendar.getInstance()
+        DatePickerDialog(this, { _, year, month, day ->
+            onDate(LocalDate.of(year, month + 1, day))
+        }, now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH)).show()
+    }
+}

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/Report.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/Report.kt
@@ -1,0 +1,9 @@
+package com.spymag.ainewsmakerfetcher
+
+import java.time.LocalDate
+
+data class Report(
+    val name: String,
+    val date: LocalDate,
+    val url: String
+)

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportAdapter.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportAdapter.kt
@@ -1,0 +1,28 @@
+package com.spymag.ainewsmakerfetcher
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+
+class ReportAdapter(context: Context, private val items: MutableList<Report>) :
+    ArrayAdapter<Report>(context, 0, items) {
+
+    fun update(newItems: List<Report>) {
+        items.clear()
+        items.addAll(newItems)
+        notifyDataSetChanged()
+    }
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: LayoutInflater.from(context).inflate(R.layout.item_report, parent, false)
+        val item = items[position]
+        val titleView: TextView = view.findViewById(R.id.tvTitle)
+        val dateView: TextView = view.findViewById(R.id.tvDate)
+        titleView.text = item.name
+        dateView.text = item.date.toString()
+        return view
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="8dp">
+
+        <Button
+            android:id="@+id/btnFromDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/from_date"/>
+
+        <Button
+            android:id="@+id/btnToDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/to_date"/>
+
+        <Button
+            android:id="@+id/btnClearFilter"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/clear_filter"/>
+
+        <Button
+            android:id="@+id/btnRefresh"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/refresh"/>
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/listReports"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_report.xml
+++ b/app/src/main/res/layout/item_report.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"/>
+
+    <TextView
+        android:id="@+id/tvDate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">AInewsMakerFetcher</string>
+    <string name="refresh">Refresh</string>
+    <string name="from_date">From</string>
+    <string name="to_date">To</string>
+    <string name="clear_filter">Clear</string>
 </resources>


### PR DESCRIPTION
## Summary
- fetch Markdown reports from GitHub repository and display in chronological order
- allow filtering by date range and manual refresh
- wire up main activity and layout with network permission

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1cc7558083249d8d186b21cd80ff