### PR TITLE
Add markdown viewer and refresh icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ReportActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -1,7 +1,10 @@
 package com.spymag.ainewsmakerfetcher
 
 import android.app.DatePickerDialog
+import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Button
 import android.widget.ListView
 import androidx.appcompat.app.AppCompatActivity
@@ -28,8 +31,14 @@ class MainActivity : AppCompatActivity() {
         listView = findViewById(R.id.listReports)
         adapter = ReportAdapter(this, mutableListOf())
         listView.adapter = adapter
-
-        findViewById<Button>(R.id.btnRefresh).setOnClickListener { fetchReports() }
+        listView.setOnItemClickListener { _, _, position, _ ->
+            val report = adapter.getItem(position)
+            if (report != null) {
+                val intent = Intent(this, ReportActivity::class.java)
+                intent.putExtra("url", report.url)
+                startActivity(intent)
+            }
+        }
         findViewById<Button>(R.id.btnClearFilter).setOnClickListener {
             fromDate = null
             toDate = null
@@ -45,6 +54,21 @@ class MainActivity : AppCompatActivity() {
         } }
 
         fetchReports()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_refresh -> {
+                fetchReports()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     private fun fetchReports() {

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
@@ -1,0 +1,28 @@
+package com.spymag.ainewsmakerfetcher
+
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import java.net.URL
+import kotlin.concurrent.thread
+
+class ReportActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_report)
+
+        val url = intent.getStringExtra("url")
+        val textView: TextView = findViewById(R.id.tvContent)
+        if (url != null) {
+            thread {
+                try {
+                    val content = URL(url).readText()
+                    runOnUiThread { textView.text = content }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    runOnUiThread { textView.text = "Failed to load report." }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/navy_blue"
+        android:pathData="M17.65,6.35c-1.63,-1.63 -3.77,-2.35 -5.9,-2.2 -3.2,0.24 -5.89,2.67 -6.5,5.82h-2.11l3.89,3.89 3.89,-3.89h-2.2c0.56,-2.15 2.44,-3.78 4.68,-3.96 1.7,-0.14 3.32,0.41 4.55,1.64 2.73,2.73 2.73,7.15 0,9.88 -2.73,2.73 -7.15,2.73 -9.88,0 -1.19,-1.19 -1.86,-2.76 -1.86,-4.44h-2c0,2.34 0.91,4.54 2.56,6.19 3.51,3.51 9.21,3.51 12.72,0 3.51,-3.51 3.51,-9.21 0,-12.72z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,28 +15,27 @@
             android:id="@+id/btnFromDate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/from_date"/>
+            android:backgroundTint="@color/navy_blue"
+            android:text="@string/from_date"
+            android:textColor="@android:color/white"/>
 
         <Button
             android:id="@+id/btnToDate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:text="@string/to_date"/>
+            android:backgroundTint="@color/navy_blue"
+            android:text="@string/to_date"
+            android:textColor="@android:color/white"/>
 
         <Button
             android:id="@+id/btnClearFilter"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:text="@string/clear_filter"/>
-
-        <Button
-            android:id="@+id/btnRefresh"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:text="@string/refresh"/>
+            android:backgroundTint="@color/navy_blue"
+            android:text="@string/clear_filter"
+            android:textColor="@android:color/white"/>
     </LinearLayout>
 
     <ListView

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/tvContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+</ScrollView>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_refresh"
+        android:title="@string/refresh"
+        android:icon="@drawable/ic_refresh"
+        app:showAsAction="always" />
+</menu>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="navy_blue">#000080</color>
 </resources>


### PR DESCRIPTION
## Summary
- Allow tapping a report to open its markdown content in a new screen
- Style filter buttons in navy blue and move refresh action to a toolbar icon
- Add refresh menu icon resource and activity layout for viewing reports

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa20f0af14832494d120ab4bf90278