### PR TITLE
Style markdown content and update theme color

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.commonmark)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
@@ -2,7 +2,11 @@ package com.spymag.ainewsmakerfetcher
 
 import android.os.Bundle
 import android.widget.TextView
+import android.text.method.LinkMovementMethod
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.text.HtmlCompat
+import org.commonmark.parser.Parser
+import org.commonmark.renderer.html.HtmlRenderer
 import java.net.URL
 import kotlin.concurrent.thread
 
@@ -17,7 +21,14 @@ class ReportActivity : AppCompatActivity() {
             thread {
                 try {
                     val content = URL(url).readText()
-                    runOnUiThread { textView.text = content }
+                    val parser = Parser.builder().build()
+                    val document = parser.parse(content)
+                    val renderer = HtmlRenderer.builder().build()
+                    val html = renderer.render(document)
+                    runOnUiThread {
+                        textView.text = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY)
+                        textView.movementMethod = LinkMovementMethod.getInstance()
+                    }
                 } catch (e: Exception) {
                     e.printStackTrace()
                     runOnUiThread { textView.text = "Failed to load report." }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,5 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="navy_blue">#000080</color>
+    <color name="navy_blue">#1976D2</color>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 appcompat = "1.6.1"
 material = "1.10.0"
+commonmark = "0.21.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -15,6 +16,7 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+commonmark = { group = "org.commonmark", name = "commonmark", version.ref = "commonmark" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- render report markdown with HTML styling and clickable links
- switch primary navy color to modern blue
- add CommonMark dependency for markdown parsing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_68aa257aed708324bfaf3dcb87aab027