### PR TITLE
Ensure status bar visible and avoid menu overlap

### DIFF
--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -2,6 +2,7 @@ package com.spymag.ainewsmakerfetcher
 
 import android.app.DatePickerDialog
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -33,8 +34,12 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_main)
-        WindowInsetsControllerCompat(window, window.decorView)
-            .show(WindowInsetsCompat.Type.systemBars())
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+        controller.show(WindowInsetsCompat.Type.systemBars())
+        val isLightMode =
+            (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) !=
+                Configuration.UI_MODE_NIGHT_YES
+        controller.isAppearanceLightStatusBars = isLightMode
 
         val root: View = findViewById(R.id.rootLayout)
         val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -8,6 +8,9 @@ import android.view.MenuItem
 import android.widget.Button
 import android.widget.ListView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import org.json.JSONArray
 import java.net.HttpURLConnection
 import java.net.URL
@@ -26,7 +29,10 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, true)
         setContentView(R.layout.activity_main)
+        WindowInsetsControllerCompat(window, window.decorView)
+            .show(WindowInsetsCompat.Type.systemBars())
 
         listView = findViewById(R.id.listReports)
         adapter = ReportAdapter(this, mutableListOf())

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -5,9 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.widget.Button
 import android.widget.ListView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -29,10 +31,28 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, true)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_main)
         WindowInsetsControllerCompat(window, window.decorView)
             .show(WindowInsetsCompat.Type.systemBars())
+
+        val root: View = findViewById(R.id.rootLayout)
+        val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))
+        val actionBarHeight = typedArray.getDimensionPixelSize(0, 0)
+        typedArray.recycle()
+        val start = root.paddingLeft
+        val end = root.paddingRight
+        val bottom = root.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(
+                start + systemBars.left,
+                systemBars.top + actionBarHeight,
+                end + systemBars.right,
+                bottom + systemBars.bottom
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         listView = findViewById(R.id.listReports)
         adapter = ReportAdapter(this, mutableListOf())

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
@@ -1,9 +1,11 @@
 package com.spymag.ainewsmakerfetcher
 
 import android.os.Bundle
+import android.view.View
 import android.widget.TextView
 import android.text.method.LinkMovementMethod
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -16,10 +18,28 @@ import kotlin.concurrent.thread
 class ReportActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, true)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_report)
         WindowInsetsControllerCompat(window, window.decorView)
             .show(WindowInsetsCompat.Type.systemBars())
+
+        val root: View = findViewById(R.id.rootLayout)
+        val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))
+        val actionBarHeight = typedArray.getDimensionPixelSize(0, 0)
+        typedArray.recycle()
+        val start = root.paddingLeft
+        val end = root.paddingRight
+        val bottom = root.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(root) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(
+                start + systemBars.left,
+                systemBars.top + actionBarHeight,
+                end + systemBars.right,
+                bottom + systemBars.bottom
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         val url = intent.getStringExtra("url")
         val textView: TextView = findViewById(R.id.tvContent)

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import android.text.method.LinkMovementMethod
+import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -20,8 +21,12 @@ class ReportActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_report)
-        WindowInsetsControllerCompat(window, window.decorView)
-            .show(WindowInsetsCompat.Type.systemBars())
+        val controller = WindowInsetsControllerCompat(window, window.decorView)
+        controller.show(WindowInsetsCompat.Type.systemBars())
+        val isLightMode =
+            (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) !=
+                Configuration.UI_MODE_NIGHT_YES
+        controller.isAppearanceLightStatusBars = isLightMode
 
         val root: View = findViewById(R.id.rootLayout)
         val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import android.widget.TextView
 import android.text.method.LinkMovementMethod
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.text.HtmlCompat
 import org.commonmark.parser.Parser
 import org.commonmark.renderer.html.HtmlRenderer
@@ -13,7 +16,10 @@ import kotlin.concurrent.thread
 class ReportActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, true)
         setContentView(R.layout.activity_report)
+        WindowInsetsControllerCompat(window, window.decorView)
+            .show(WindowInsetsCompat.Type.systemBars())
 
         val url = intent.getStringExtra("url")
         val textView: TextView = findViewById(R.id.tvContent)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,7 +3,11 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp">
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="16dp"
+    android:paddingTop="?attr/actionBarSize"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp"
-    android:paddingBottom="16dp"
-    android:paddingTop="?attr/actionBarSize"
-    android:fitsSystemWindows="true">
+    android:paddingBottom="16dp">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/rootLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingTop="?attr/actionBarSize"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/tvContent"

--- a/app/src/main/res/layout/activity_report.xml
+++ b/app/src/main/res/layout/activity_report.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingTop="?attr/actionBarSize"
+    android:fitsSystemWindows="true">
 
     <TextView
         android:id="@+id/tvContent"


### PR DESCRIPTION
## Summary
- Show system status bars on activity launch so time, battery, and wifi icons remain visible.
- Add padding to main and report layouts to keep buttons and content below the app's main menu.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

I have read and followed the instructions in AGENTS.md.


------
https://chatgpt.com/codex/tasks/task_b_68aae9cfeedc8324892b578f07b7d6ab