### PR TITLE
Add optional OpenAI news summary

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,14 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+}
+
+val localProps = Properties()
+val localPropsFile = rootProject.file("local.properties")
+if (localPropsFile.exists()) {
+    localProps.load(localPropsFile.inputStream())
 }
 
 android {
@@ -15,6 +23,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        val openAiKey = localProps.getProperty("OPENAI_API_KEY", "")
+        buildConfigField("String", "OPENAI_API_KEY", "\"$openAiKey\"")
     }
 
     buildTypes {
@@ -32,6 +43,9 @@ android {
     }
     kotlinOptions {
         jvmTarget = "11"
+    }
+    buildFeatures {
+        buildConfig = true
     }
 }
 

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -9,12 +9,17 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.Button
 import android.widget.ListView
+import android.widget.Spinner
+import android.widget.TextView
+import android.widget.ArrayAdapter
+import android.widget.AdapterView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import org.json.JSONArray
+import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
 import java.time.LocalDate
@@ -25,6 +30,7 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var listView: ListView
     private lateinit var adapter: ReportAdapter
+    private lateinit var summaryView: TextView
 
     private val allReports = mutableListOf<Report>()
     private var fromDate: LocalDate? = null
@@ -57,6 +63,30 @@ class MainActivity : AppCompatActivity() {
                 bottom + systemBars.bottom
             )
             WindowInsetsCompat.CONSUMED
+        }
+
+        summaryView = findViewById(R.id.tvSummary)
+        val spinner: Spinner = findViewById(R.id.spinnerSummary)
+        ArrayAdapter.createFromResource(
+            this,
+            R.array.summary_options,
+            android.R.layout.simple_spinner_item
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            spinner.adapter = adapter
+        }
+        spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
+                if (position == 1) {
+                    generateSummary()
+                } else {
+                    summaryView.visibility = View.GONE
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>) {
+                summaryView.visibility = View.GONE
+            }
         }
 
         listView = findViewById(R.id.listReports)
@@ -150,5 +180,64 @@ class MainActivity : AppCompatActivity() {
         DatePickerDialog(this, { _, year, month, day ->
             onDate(LocalDate.of(year, month + 1, day))
         }, now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH)).show()
+    }
+
+    private fun generateSummary() {
+        val recent = allReports.filter { !it.date.isBefore(LocalDate.now().minusDays(3)) }
+        if (recent.isEmpty()) {
+            summaryView.visibility = View.VISIBLE
+            summaryView.text = getString(R.string.summary_none)
+            return
+        }
+        summaryView.visibility = View.VISIBLE
+        summaryView.text = getString(R.string.summary_loading)
+        thread {
+            try {
+                val builder = StringBuilder()
+                recent.forEach { report ->
+                    val text = URL(report.url).readText()
+                    builder.append(text).append("\n\n")
+                }
+                val summary = fetchSummaryFromOpenAI(builder.toString())
+                runOnUiThread { summaryView.text = summary }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                runOnUiThread { summaryView.text = getString(R.string.summary_failed) }
+            }
+        }
+    }
+
+    private fun fetchSummaryFromOpenAI(text: String): String {
+        val apiKey = BuildConfig.OPENAI_API_KEY
+        if (apiKey.isBlank()) {
+            return getString(R.string.summary_no_key)
+        }
+        val url = URL("https://api.openai.com/v1/chat/completions")
+        val conn = url.openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.setRequestProperty("Authorization", "Bearer $apiKey")
+        conn.setRequestProperty("Content-Type", "application/json")
+        conn.doOutput = true
+        val payload = JSONObject().apply {
+            put("model", "gpt-3.5-turbo")
+            put("messages", JSONArray().apply {
+                put(JSONObject().apply {
+                    put("role", "system")
+                    put("content", "Summarize the following news reports.")
+                })
+                put(JSONObject().apply {
+                    put("role", "user")
+                    put("content", text)
+                })
+            })
+        }
+        conn.outputStream.use { it.write(payload.toString().toByteArray()) }
+        val response = conn.inputStream.bufferedReader().use { it.readText() }
+        val json = JSONObject(response)
+        return json.getJSONArray("choices")
+            .getJSONObject(0)
+            .getJSONObject("message")
+            .getString("content")
+            .trim()
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,6 +8,20 @@
     android:paddingEnd="16dp"
     android:paddingBottom="16dp">
 
+    <Spinner
+        android:id="@+id/spinnerSummary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:prompt="@string/select_summary" />
+
+    <TextView
+        android:id="@+id/tvSummary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:visibility="gone" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,15 @@
     <string name="from_date">From</string>
     <string name="to_date">To</string>
     <string name="clear_filter">Clear</string>
+    <string name="select_summary">Summary (optional)</string>
+    <string name="summary_option_none">No summary</string>
+    <string name="summary_option_last3">Last 3 days</string>
+    <string-array name="summary_options">
+        <item>@string/summary_option_none</item>
+        <item>@string/summary_option_last3</item>
+    </string-array>
+    <string name="summary_loading">Generating summary…</string>
+    <string name="summary_failed">Failed to generate summary.</string>
+    <string name="summary_no_key">OpenAI key not configured.</string>
+    <string name="summary_none">No reports from last 3 days.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add spinner to request an optional AI summary of the last three days of reports
- read OpenAI API key from `local.properties` and expose via `BuildConfig`
- integrate OpenAI Chat Completions to generate a summary displayed above report list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

I have read and followed the instructions in `AGENTS.md`.

------
https://chatgpt.com/codex/tasks/task_b_68ab7741ff04832494ad3c78fc012204