### PR TITLE
Add tabs for news and daily actions

### DIFF
--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/MainActivity.kt
@@ -2,18 +2,22 @@ package com.spymag.ainewsmakerfetcher
 
 import android.app.DatePickerDialog
 import android.content.Intent
+import android.net.Uri
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.widget.Button
+import android.widget.TextView
 import android.widget.ListView
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.google.android.material.tabs.TabLayout
 import org.json.JSONArray
 import java.net.HttpURLConnection
 import java.net.URL
@@ -25,6 +29,15 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var listView: ListView
     private lateinit var adapter: ReportAdapter
+    private lateinit var layoutNews: View
+    private lateinit var layoutDaily: View
+    private lateinit var folderText: TextView
+
+    private val folderPicker = registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri: Uri? ->
+        if (uri != null) {
+            folderText.text = uri.toString()
+        }
+    }
 
     private val allReports = mutableListOf<Report>()
     private var fromDate: LocalDate? = null
@@ -42,6 +55,26 @@ class MainActivity : AppCompatActivity() {
         controller.isAppearanceLightStatusBars = isLightMode
 
         val root: View = findViewById(R.id.rootLayout)
+        val tabLayout: TabLayout = findViewById(R.id.tabLayout)
+        layoutNews = findViewById(R.id.layoutNews)
+        layoutDaily = findViewById(R.id.layoutDaily)
+        folderText = findViewById(R.id.tvFolder)
+
+        tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab?) {
+                if (tab?.position == 0) {
+                    layoutNews.visibility = View.VISIBLE
+                    layoutDaily.visibility = View.GONE
+                } else {
+                    layoutNews.visibility = View.GONE
+                    layoutDaily.visibility = View.VISIBLE
+                }
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab?) {}
+
+            override fun onTabReselected(tab: TabLayout.Tab?) {}
+        })
         val typedArray = theme.obtainStyledAttributes(intArrayOf(android.R.attr.actionBarSize))
         val actionBarHeight = typedArray.getDimensionPixelSize(0, 0)
         typedArray.recycle()
@@ -83,6 +116,10 @@ class MainActivity : AppCompatActivity() {
             toDate = date
             applyFilter()
         } }
+
+        findViewById<Button>(R.id.btnSelectFolder).setOnClickListener {
+            folderPicker.launch(null)
+        }
 
         fetchReports()
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/rootLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -8,43 +9,85 @@
     android:paddingEnd="16dp"
     android:paddingBottom="16dp">
 
-    <LinearLayout
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginBottom="8dp">
+        android:layout_height="wrap_content">
+        <com.google.android.material.tabs.TabItem
+            android:text="@string/news_tab"/>
+        <com.google.android.material.tabs.TabItem
+            android:text="@string/daily_actions_tab"/>
+    </com.google.android.material.tabs.TabLayout>
 
-        <Button
-            android:id="@+id/btnFromDate"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:backgroundTint="@color/navy_blue"
-            android:text="@string/from_date"
-            android:textColor="@android:color/white"/>
-
-        <Button
-            android:id="@+id/btnToDate"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:backgroundTint="@color/navy_blue"
-            android:text="@string/to_date"
-            android:textColor="@android:color/white"/>
-
-        <Button
-            android:id="@+id/btnClearFilter"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:backgroundTint="@color/navy_blue"
-            android:text="@string/clear_filter"
-            android:textColor="@android:color/white"/>
-    </LinearLayout>
-
-    <ListView
-        android:id="@+id/listReports"
+    <LinearLayout
+        android:id="@+id/layoutNews"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"/>
+        android:layout_weight="1"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="8dp">
+
+            <Button
+                android:id="@+id/btnFromDate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:backgroundTint="@color/navy_blue"
+                android:text="@string/from_date"
+                android:textColor="@android:color/white"/>
+
+            <Button
+                android:id="@+id/btnToDate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:backgroundTint="@color/navy_blue"
+                android:text="@string/to_date"
+                android:textColor="@android:color/white"/>
+
+            <Button
+                android:id="@+id/btnClearFilter"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:backgroundTint="@color/navy_blue"
+                android:text="@string/clear_filter"
+                android:textColor="@android:color/white"/>
+        </LinearLayout>
+
+        <ListView
+            android:id="@+id/listReports"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/layoutDaily"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <Button
+            android:id="@+id/btnSelectFolder"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:backgroundTint="@color/navy_blue"
+            android:text="@string/select_folder"
+            android:textColor="@android:color/white"/>
+
+        <TextView
+            android:id="@+id/tvFolder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/no_folder_selected"/>
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="from_date">From</string>
     <string name="to_date">To</string>
     <string name="clear_filter">Clear</string>
+    <string name="news_tab">News</string>
+    <string name="daily_actions_tab">Daily actions</string>
+    <string name="select_folder">Select Folder</string>
+    <string name="no_folder_selected">No folder selected</string>
 </resources>


### PR DESCRIPTION
## Summary
- add TabLayout with News and Daily Actions sections
- allow selecting a folder for daily actions via Storage Access Framework

## Testing
- `./gradlew test` *(fails: SDK location not found)*

I have read and followed the instructions in `AGENTS.md`.

------
https://chatgpt.com/codex/tasks/task_b_68acd1bf55508324afead9edc54f8db4