### PR TITLE
Fix Properties reference in Gradle script

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,12 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
 }
 
 // Read local.properties for sensitive information
-val localProperties = java.util.Properties()
+val localProperties = Properties()
 val localPropertiesFile = rootProject.file("local.properties")
 if (localPropertiesFile.exists()) {
     localProperties.load(localPropertiesFile.inputStream())


### PR DESCRIPTION
## Summary
- fix unresolved `java.util` reference in `app/build.gradle.kts` by importing `java.util.Properties`

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. SDK location not found)*

I have read and followed the AGENTS.md instructions.

------
https://chatgpt.com/codex/tasks/task_b_68af71a6f780832483b2e29aff699e1c