### PR TITLE
Fix date parsing for actions filter

### DIFF
--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ActionsFragment.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ActionsFragment.kt
@@ -116,14 +116,12 @@ class ActionsFragment : Fragment() {
     private fun parseActions(json: String): List<Report> {
         val arr = JSONArray(json)
         val list = mutableListOf<Report>()
-        val dateRegex = Regex("(\\d{4}-\\d{2}-\\d{2})")
         for (i in 0 until arr.length()) {
             val obj = arr.getJSONObject(i)
             val name = obj.getString("name")
             if (name.endsWith(".md")) {
                 val url = obj.getString("download_url")
-                val match = dateRegex.find(name)
-                val date = match?.let { LocalDate.parse(it.value) } ?: LocalDate.MIN
+                val date = parseDateFromFileName(name) ?: LocalDate.MIN
                 list.add(Report(name, date, url))
             }
         }

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/DateUtils.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/DateUtils.kt
@@ -1,12 +1,22 @@
 package com.spymag.ainewsmakerfetcher
 
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
-private val dateRegex = Regex("(\\d{4}[-_]\\d{2}[-_]\\d{2})")
+private val dateRegex = Regex("(\\d{4}[-_]\\d{2}[-_]\\d{2}|\\d{8})")
 
+/**
+ * Extracts [LocalDate] from a filename.
+ *
+ * Supports `yyyy-MM-dd`, `yyyy_MM_dd`, and `yyyyMMdd` formats.
+ */
 fun parseDateFromFileName(name: String): LocalDate? {
-    val match = dateRegex.find(name) ?: return null
-    val normalized = match.value.replace('_', '-')
-    return runCatching { LocalDate.parse(normalized) }.getOrNull()
+    val value = dateRegex.find(name)?.value ?: return null
+    return when {
+        value.contains('-') || value.contains('_') ->
+            runCatching { LocalDate.parse(value.replace('_', '-')) }.getOrNull()
+        else ->
+            runCatching { LocalDate.parse(value, DateTimeFormatter.BASIC_ISO_DATE) }.getOrNull()
+    }
 }
 

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/DateUtils.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/DateUtils.kt
@@ -1,0 +1,12 @@
+package com.spymag.ainewsmakerfetcher
+
+import java.time.LocalDate
+
+private val dateRegex = Regex("(\\d{4}[-_]\\d{2}[-_]\\d{2})")
+
+fun parseDateFromFileName(name: String): LocalDate? {
+    val match = dateRegex.find(name) ?: return null
+    val normalized = match.value.replace('_', '-')
+    return runCatching { LocalDate.parse(normalized) }.getOrNull()
+}
+

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportsFragment.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportsFragment.kt
@@ -119,14 +119,12 @@ class ReportsFragment : Fragment() {
     private fun parseReports(json: String): List<Report> {
         val arr = JSONArray(json)
         val list = mutableListOf<Report>()
-        val dateRegex = Regex("(\\d{4}-\\d{2}-\\d{2})")
         for (i in 0 until arr.length()) {
             val obj = arr.getJSONObject(i)
             val name = obj.getString("name")
             if (name.endsWith(".md")) {
                 val url = obj.getString("download_url")
-                val match = dateRegex.find(name)
-                val date = match?.let { LocalDate.parse(it.value) } ?: LocalDate.MIN
+                val date = parseDateFromFileName(name) ?: LocalDate.MIN
                 list.add(Report(name, date, url))
             }
         }

--- a/app/src/test/java/com/spymag/ainewsmakerfetcher/DateUtilsTest.kt
+++ b/app/src/test/java/com/spymag/ainewsmakerfetcher/DateUtilsTest.kt
@@ -1,0 +1,25 @@
+package com.spymag.ainewsmakerfetcher
+
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DateUtilsTest {
+    @Test
+    fun parsesHyphenSeparatedDates() {
+        val date = parseDateFromFileName("report-2024-05-10.md")
+        assertEquals(LocalDate.of(2024, 5, 10), date)
+    }
+
+    @Test
+    fun parsesUnderscoreSeparatedDates() {
+        val date = parseDateFromFileName("report_2024_05_10.md")
+        assertEquals(LocalDate.of(2024, 5, 10), date)
+    }
+
+    @Test
+    fun parsesCompactDates() {
+        val date = parseDateFromFileName("report_20250827.md")
+        assertEquals(LocalDate.of(2025, 8, 27), date)
+    }
+}


### PR DESCRIPTION
## Summary
- handle underscores in filenames when parsing dates
- share date parsing helper across fragments

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.android.application', version: '8.12.2', apply: false] was not found)*

I have read and followed the AGENTS.md guidelines.

------
https://chatgpt.com/codex/tasks/task_b_68b200be0a4883248f7ad0058e95e548