### PR TITLE
Add text-to-speech playback for summaries

### DIFF
--- a/app/src/main/res/layout/fragment_reports.xml
+++ b/app/src/main/res/layout/fragment_reports.xml
@@ -21,6 +21,14 @@
         android:layout_marginBottom="8dp"
         android:visibility="gone" />
 
+    <Button
+        android:id="@+id/btnListenSummary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/listen_summary"
+        android:visibility="gone" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="summary_failed">Failed to generate summary.</string>
     <string name="summary_no_key">OpenAI key not configured.</string>
     <string name="summary_none">No reports from last 3 days.</string>
+    <string name="listen_summary">Listen to summary</string>
     <string name="tab_reports">AI News</string>
     <string name="tab_actions">Actions for today</string>
 </resources>


### PR DESCRIPTION
## Summary
- integrate Android TextToSpeech and add a Listen button to hear generated summaries
- display button only when a summary is available and shut down TextToSpeech on destroy

## Testing
- `./gradlew test` *(fails: SDK location not found)*

I have read and followed the instructions in `AGENTS.md`.

------
https://chatgpt.com/codex/tasks/task_b_68bc2ff112dc8324b788826b4ad9ac77