### PR TITLE
Add text-to-speech playback for summaries

### DIFF
--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportsFragment.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ReportsFragment.kt
@@ -2,21 +2,28 @@ package com.spymag.ainewsmakerfetcher
 
 import android.app.DatePickerDialog
 import android.content.Intent
+import android.media.MediaPlayer
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.ListView
-import android.widget.Spinner
-import android.widget.TextView
 import android.widget.ArrayAdapter
 import android.widget.AdapterView
+import android.widget.Button
+import android.widget.ListView
+import android.widget.SeekBar
+import android.widget.Spinner
+import android.widget.TextView
 import androidx.fragment.app.Fragment
 import org.json.JSONArray
 import org.json.JSONObject
 import java.net.HttpURLConnection
 import java.net.URL
+import java.io.File
 import java.time.LocalDate
 import java.util.Calendar
 import kotlin.concurrent.thread
@@ -26,6 +33,25 @@ class ReportsFragment : Fragment() {
     private lateinit var listView: ListView
     private lateinit var adapter: ReportAdapter
     private lateinit var summaryView: TextView
+    private lateinit var listenButton: Button
+    private lateinit var pauseButton: Button
+    private lateinit var seekBar: SeekBar
+    private lateinit var timeView: TextView
+    private var tts: TextToSpeech? = null
+    private var mediaPlayer: MediaPlayer? = null
+    private var audioFile: File? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private val updateProgress = object : Runnable {
+        override fun run() {
+            mediaPlayer?.let { mp ->
+                seekBar.progress = mp.currentPosition
+                timeView.text = "${formatTime(mp.currentPosition)} / ${formatTime(mp.duration)}"
+                if (mp.isPlaying) {
+                    handler.postDelayed(this, 500)
+                }
+            }
+        }
+    }
 
     private val allReports = mutableListOf<Report>()
     private var fromDate: LocalDate? = null
@@ -43,6 +69,25 @@ class ReportsFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         summaryView = view.findViewById(R.id.tvSummary)
+        listenButton = view.findViewById(R.id.btnListenSummary)
+        pauseButton = view.findViewById(R.id.btnPauseSummary)
+        seekBar = view.findViewById(R.id.seekSummary)
+        timeView = view.findViewById(R.id.tvAudioTime)
+        listenButton.setOnClickListener { speakSummary() }
+        pauseButton.setOnClickListener { togglePlayback() }
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(sb: SeekBar, progress: Int, fromUser: Boolean) {
+                if (fromUser) {
+                    mediaPlayer?.seekTo(progress)
+                    timeView.text = "${formatTime(progress)} / ${formatTime(mediaPlayer?.duration ?: 0)}"
+                }
+            }
+
+            override fun onStartTrackingTouch(sb: SeekBar) {}
+
+            override fun onStopTrackingTouch(sb: SeekBar) {}
+        })
+        tts = TextToSpeech(requireContext()) { _ -> }
         val spinner: Spinner = view.findViewById(R.id.spinnerSummary)
         ArrayAdapter.createFromResource(
             requireContext(),
@@ -58,11 +103,13 @@ class ReportsFragment : Fragment() {
                     generateSummary()
                 } else {
                     summaryView.visibility = View.GONE
+                    hideAudioControls()
                 }
             }
 
             override fun onNothingSelected(parent: AdapterView<*>) {
                 summaryView.visibility = View.GONE
+                hideAudioControls()
             }
         }
 
@@ -152,10 +199,12 @@ class ReportsFragment : Fragment() {
         if (recent.isEmpty()) {
             summaryView.visibility = View.VISIBLE
             summaryView.text = getString(R.string.summary_none)
+            hideAudioControls()
             return
         }
         summaryView.visibility = View.VISIBLE
         summaryView.text = getString(R.string.summary_loading)
+        hideAudioControls()
         thread {
             try {
                 val builder = StringBuilder()
@@ -164,12 +213,103 @@ class ReportsFragment : Fragment() {
                     builder.append(text).append("\n\n")
                 }
                 val summary = fetchSummaryFromOpenAI(builder.toString())
-                activity?.runOnUiThread { summaryView.text = summary }
+                activity?.runOnUiThread {
+                    summaryView.text = summary
+                    val hide = summary == getString(R.string.summary_no_key) || summary == getString(R.string.summary_failed)
+                    if (hide) {
+                        hideAudioControls()
+                    } else {
+                        listenButton.visibility = View.VISIBLE
+                    }
+                    mediaPlayer?.release()
+                    mediaPlayer = null
+                    audioFile?.delete()
+                    audioFile = null
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
-                activity?.runOnUiThread { summaryView.text = getString(R.string.summary_failed) }
+                activity?.runOnUiThread {
+                    summaryView.text = getString(R.string.summary_failed)
+                    hideAudioControls()
+                }
             }
         }
+    }
+
+    private fun speakSummary() {
+        val text = summaryView.text.toString()
+        if (text.isBlank()) return
+        audioFile?.let {
+            startPlayback(true)
+            return
+        }
+        val file = File(requireContext().cacheDir, "summary.wav")
+        audioFile = file
+        tts?.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+            override fun onStart(utteranceId: String?) {}
+            override fun onDone(utteranceId: String?) {
+                activity?.runOnUiThread { startPlayback(true) }
+            }
+            override fun onError(utteranceId: String?) {
+                audioFile = null
+            }
+        })
+        tts?.synthesizeToFile(text, null, file, "summary")
+    }
+
+    private fun startPlayback(fromStart: Boolean) {
+        val file = audioFile ?: return
+        if (fromStart) {
+            mediaPlayer?.release()
+            mediaPlayer = MediaPlayer().apply {
+                setDataSource(file.absolutePath)
+                setOnPreparedListener { mp ->
+                    seekBar.max = mp.duration
+                    pauseButton.text = getString(R.string.pause_summary)
+                    pauseButton.visibility = View.VISIBLE
+                    seekBar.visibility = View.VISIBLE
+                    timeView.visibility = View.VISIBLE
+                    mp.start()
+                    handler.post(updateProgress)
+                }
+                setOnCompletionListener {
+                    pauseButton.text = getString(R.string.pause_summary)
+                    handler.removeCallbacks(updateProgress)
+                }
+                prepareAsync()
+            }
+        } else {
+            mediaPlayer?.start()
+            pauseButton.text = getString(R.string.pause_summary)
+            handler.post(updateProgress)
+        }
+    }
+
+    private fun togglePlayback() {
+        mediaPlayer?.let { mp ->
+            if (mp.isPlaying) {
+                mp.pause()
+                pauseButton.text = getString(R.string.resume_summary)
+            } else {
+                mp.start()
+                pauseButton.text = getString(R.string.pause_summary)
+                handler.post(updateProgress)
+            }
+        }
+    }
+
+    private fun formatTime(ms: Int): String {
+        val totalSeconds = ms / 1000
+        val minutes = totalSeconds / 60
+        val seconds = totalSeconds % 60
+        return String.format("%d:%02d", minutes, seconds)
+    }
+
+    private fun hideAudioControls() {
+        listenButton.visibility = View.GONE
+        pauseButton.visibility = View.GONE
+        seekBar.visibility = View.GONE
+        timeView.visibility = View.GONE
     }
 
     private fun fetchSummaryFromOpenAI(text: String): String {
@@ -204,5 +344,12 @@ class ReportsFragment : Fragment() {
             .getJSONObject("message")
             .getString("content")
             .trim()
+    }
+
+    override fun onDestroy() {
+        tts?.shutdown()
+        mediaPlayer?.release()
+        handler.removeCallbacksAndMessages(null)
+        super.onDestroy()
     }
 }

--- a/app/src/main/res/layout/fragment_reports.xml
+++ b/app/src/main/res/layout/fragment_reports.xml
@@ -21,6 +21,36 @@
         android:layout_marginBottom="8dp"
         android:visibility="gone" />
 
+    <Button
+        android:id="@+id/btnListenSummary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/listen_summary"
+        android:visibility="gone" />
+
+    <Button
+        android:id="@+id/btnPauseSummary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/pause_summary"
+        android:visibility="gone" />
+
+    <SeekBar
+        android:id="@+id/seekSummary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tvAudioTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:visibility="gone" />
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,9 @@
     <string name="summary_failed">Failed to generate summary.</string>
     <string name="summary_no_key">OpenAI key not configured.</string>
     <string name="summary_none">No reports from last 3 days.</string>
+    <string name="listen_summary">Listen to summary</string>
+    <string name="pause_summary">Pause</string>
+    <string name="resume_summary">Resume</string>
     <string name="tab_reports">AI News</string>
     <string name="tab_actions">Actions for today</string>
 </resources>


### PR DESCRIPTION
## Summary
- integrate Android TextToSpeech and add a Listen button to hear generated summaries
- add pause/resume playback with seek bar and timer for summary audio
- display button only when a summary is available and shut down TextToSpeech on destroy

## Testing
- `./gradlew test` *(fails: SDK location not found)*

I have read and followed the instructions in `AGENTS.md`.

------
https://chatgpt.com/codex/tasks/task_b_68bc2ff112dc8324b788826b4ad9ac77