### PR TITLE
Adapt icon and markdown styles for dark theme

### DIFF
--- a/app/src/main/assets/github_markdown.css
+++ b/app/src/main/assets/github_markdown.css
@@ -16,9 +16,13 @@ body {
         color: #f0f6fc;
         background-color: #0d1117;
     }
-    
+
     h1, h2, h3, h4, h5, h6 {
-        color: #f0f6fc;
+        color: #c9d1d9;
+    }
+
+    h1, h2 {
+        border-bottom: 1px solid #30363d;
     }
     
     code, .highlight {
@@ -34,17 +38,25 @@ body {
         color: #8b949e;
         border-left-color: #30363d;
     }
-    
+
     table tr {
         background-color: #0d1117;
         border-top-color: #21262d;
     }
-    
+
     table th, table td {
         border-color: #30363d;
     }
-    
+
+    table th {
+        background-color: #0d1117;
+    }
+
     table tr:nth-child(2n) {
+        background-color: #161b22;
+    }
+
+    table tr:nth-child(2n) th {
         background-color: #161b22;
     }
     

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -5,7 +5,7 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="@color/ic_launcher_background"
+        android:fillColor="?attr/colorSurface"
         android:pathData="M0,0h108v108h-108z" />
     <path
         android:fillColor="#00000000"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="ic_launcher_background">#333333</color>
-</resources>

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="ic_launcher_background">#DC943D</color>
-</resources>


### PR DESCRIPTION
## Summary
- make launcher icon background follow current theme
- refine markdown dark theme table and heading styling for better contrast

## Testing
- `./gradlew test` *(fails: Plugin [id: 'com.android.application', version: '7.4.2', apply: false] was not found)*

I have read and followed the instructions in `AGENTS.md`.

------
https://chatgpt.com/codex/tasks/task_b_68bdd1a7261c8324a5b12766bb01d1cf