### PR TITLE
Make icons theme aware and remove dark variant

### DIFF
--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -3,8 +3,9 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
     <path
-        android:fillColor="@color/navy_blue"
+        android:fillColor="@android:color/white"
         android:pathData="M17.65,6.35c-1.63,-1.63 -3.77,-2.35 -5.9,-2.2 -3.2,0.24 -5.89,2.67 -6.5,5.82h-2.11l3.89,3.89 3.89,-3.89h-2.2c0.56,-2.15 2.44,-3.78 4.68,-3.96 1.7,-0.14 3.32,0.41 4.55,1.64 2.73,2.73 2.73,7.15 0,9.88 -2.73,2.73 -7.15,2.73 -9.88,0 -1.19,-1.19 -1.86,-2.76 -1.86,-4.44h-2c0,2.34 0.91,4.54 2.56,6.19 3.51,3.51 9.21,3.51 12.72,0 3.51,-3.51 3.51,-9.21 0,-12.72z" />
 </vector>

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -2,8 +2,9 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="@android:color/white"
         android:pathData="M6,6h12v12H6z" />
 </vector>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="ic_launcher_background">#333333</color>
-</resources>


### PR DESCRIPTION
## Summary
- tint refresh and stop icons with theme color and allow automatic adaptation
- drop night-specific color resource to avoid separate dark icon

## Testing
- `./gradlew test` *(fails: SDK location not found)*

I have read and followed the AGENTS.md instructions.

------
https://chatgpt.com/codex/tasks/task_b_68bf0c977818832499a0c1ca756c43bd