### PR TITLE
Add inventory check scheduling and shopping suggestions

### DIFF
--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/ActionsFragment.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/ActionsFragment.kt
@@ -8,24 +8,43 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ListView
+import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import com.google.android.material.slider.Slider
 import org.json.JSONArray
 import java.io.FileNotFoundException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.util.Calendar
+import java.util.Locale
 import kotlin.concurrent.thread
 
 class ActionsFragment : Fragment() {
 
     private lateinit var listView: ListView
     private lateinit var adapter: ReportAdapter
+    private lateinit var checkManager: InventoryCheckManager
+    private lateinit var intervalSlider: Slider
+    private lateinit var intervalValueView: TextView
+    private lateinit var nextCheckView: TextView
+    private lateinit var lastReportView: TextView
 
     private val allActions = mutableListOf<Report>()
     private var fromDate: LocalDate? = null
     private var toDate: LocalDate? = null
+
+    private val dateFormatter: DateTimeFormatter by lazy {
+        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        checkManager = InventoryCheckManager(CheckSettingsRepository(requireContext()))
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,6 +56,25 @@ class ActionsFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        intervalSlider = view.findViewById(R.id.sliderCheckInterval)
+        intervalValueView = view.findViewById(R.id.tvCheckIntervalValue)
+        nextCheckView = view.findViewById(R.id.tvNextCheckDate)
+        lastReportView = view.findViewById(R.id.tvLastShoppingReport)
+
+        intervalSlider.apply {
+            valueFrom = MIN_CHECK_INTERVAL_DAYS.toFloat()
+            valueTo = MAX_CHECK_INTERVAL_DAYS.toFloat()
+            stepSize = 1f
+            value = checkManager.currentInterval().toFloat()
+            addOnChangeListener { _, sliderValue, fromUser ->
+                val days = sliderValue.toInt().coerceIn(MIN_CHECK_INTERVAL_DAYS, MAX_CHECK_INTERVAL_DAYS)
+                if (fromUser) {
+                    checkManager.updateInterval(days)
+                }
+                updateCheckSummary(days)
+            }
+        }
 
         listView = view.findViewById(R.id.listActions)
         adapter = ReportAdapter(requireContext(), mutableListOf())
@@ -65,10 +103,30 @@ class ActionsFragment : Fragment() {
         } }
 
         fetchActions()
+        updateCheckSummary()
     }
 
     fun refreshData() {
         fetchActions()
+    }
+
+    fun registerInventorySnapshot(date: LocalDate, detectedItems: Collection<String>) {
+        val snapshot = InventorySnapshot(date, detectedItems.toList())
+        val report = checkManager.registerSnapshot(snapshot)
+        if (report != null && isAdded) {
+            val message = getString(R.string.shopping_report_toast, formatItems(report.missingItems))
+            Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
+        }
+        if (this::intervalValueView.isInitialized && this::intervalSlider.isInitialized) {
+            updateCheckSummary()
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (this::intervalValueView.isInitialized && this::intervalSlider.isInitialized) {
+            updateCheckSummary()
+        }
     }
 
     private fun fetchActions() {
@@ -142,5 +200,42 @@ class ActionsFragment : Fragment() {
         DatePickerDialog(requireContext(), { _, year, month, day ->
             onDate(LocalDate.of(year, month + 1, day))
         }, now.get(Calendar.YEAR), now.get(Calendar.MONTH), now.get(Calendar.DAY_OF_MONTH)).show()
+    }
+
+    private fun updateCheckSummary(intervalOverride: Int? = null) {
+        val interval = intervalOverride ?: checkManager.currentInterval()
+        intervalValueView.text = getString(R.string.check_interval_value, interval)
+
+        val nextDate = checkManager.nextCheckDate()
+        nextCheckView.text = nextDate?.let {
+            getString(R.string.check_next_date_value, dateFormatter.format(it))
+        } ?: getString(R.string.check_next_date_unknown)
+
+        checkManager.lastReport()?.let { report ->
+            if (report.missingItems.isNotEmpty()) {
+                val formattedDate = dateFormatter.format(report.generatedOn)
+                val items = formatItems(report.missingItems)
+                lastReportView.text = getString(R.string.shopping_report_message, formattedDate, items)
+                return
+            }
+        }
+        lastReportView.text = getString(R.string.shopping_report_none)
+
+        val sliderValue = intervalSlider.value.toInt()
+        if (sliderValue != interval) {
+            intervalSlider.value = interval.toFloat()
+        }
+    }
+
+    private fun formatItems(items: List<String>): String {
+        return items.joinToString(", ") { item ->
+            item.replaceFirstChar { char ->
+                if (char.isLowerCase()) {
+                    char.titlecase(Locale.getDefault())
+                } else {
+                    char.toString()
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/CheckSettingsRepository.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/CheckSettingsRepository.kt
@@ -1,0 +1,94 @@
+package com.spymag.ainewsmakerfetcher
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.LocalDate
+
+class CheckSettingsRepository(context: Context) : CheckSettingsStorage {
+
+    private val prefs: SharedPreferences =
+        context.getSharedPreferences("inventory_checks", Context.MODE_PRIVATE)
+
+    override fun getIntervalDays(): Int {
+        val stored = prefs.getInt(KEY_INTERVAL_DAYS, MIN_CHECK_INTERVAL_DAYS)
+        return stored.coerceIn(MIN_CHECK_INTERVAL_DAYS, MAX_CHECK_INTERVAL_DAYS)
+    }
+
+    override fun setIntervalDays(days: Int) {
+        val clamped = days.coerceIn(MIN_CHECK_INTERVAL_DAYS, MAX_CHECK_INTERVAL_DAYS)
+        prefs.edit().putInt(KEY_INTERVAL_DAYS, clamped).apply()
+    }
+
+    override fun getLastSnapshotDate(): LocalDate? {
+        return prefs.getString(KEY_LAST_SNAPSHOT_DATE, null)?.let { LocalDate.parse(it) }
+    }
+
+    override fun setLastSnapshotDate(date: LocalDate) {
+        prefs.edit().putString(KEY_LAST_SNAPSHOT_DATE, date.toString()).apply()
+    }
+
+    override fun getItemFrequencies(): Map<String, Int> {
+        val raw = prefs.getString(KEY_ITEM_FREQUENCIES, null) ?: return emptyMap()
+        return try {
+            val json = JSONObject(raw)
+            buildMap {
+                val iterator = json.keys()
+                while (iterator.hasNext()) {
+                    val key = iterator.next()
+                    put(key, json.getInt(key))
+                }
+            }
+        } catch (_: Exception) {
+            emptyMap()
+        }
+    }
+
+    override fun setItemFrequencies(frequencies: Map<String, Int>) {
+        val json = JSONObject()
+        frequencies.forEach { (key, value) ->
+            json.put(key, value)
+        }
+        prefs.edit().putString(KEY_ITEM_FREQUENCIES, json.toString()).apply()
+    }
+
+    override fun getLastShoppingReport(): ShoppingListReport? {
+        val raw = prefs.getString(KEY_LAST_SHOPPING_REPORT, null) ?: return null
+        return try {
+            val json = JSONObject(raw)
+            val date = LocalDate.parse(json.getString("date"))
+            val interval = json.getInt("interval")
+            val itemsArray = json.getJSONArray("items")
+            val items = mutableListOf<String>()
+            for (i in 0 until itemsArray.length()) {
+                items += itemsArray.getString(i)
+            }
+            ShoppingListReport(date, items, interval)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun setLastShoppingReport(report: ShoppingListReport?) {
+        val editor = prefs.edit()
+        if (report == null) {
+            editor.remove(KEY_LAST_SHOPPING_REPORT)
+        } else {
+            val json = JSONObject().apply {
+                put("date", report.generatedOn.toString())
+                put("interval", report.intervalDays)
+                put("items", JSONArray(report.missingItems))
+            }
+            editor.putString(KEY_LAST_SHOPPING_REPORT, json.toString())
+        }
+        editor.apply()
+    }
+
+    companion object {
+        private const val KEY_INTERVAL_DAYS = "interval_days"
+        private const val KEY_LAST_SNAPSHOT_DATE = "last_snapshot_date"
+        private const val KEY_ITEM_FREQUENCIES = "item_frequencies"
+        private const val KEY_LAST_SHOPPING_REPORT = "last_shopping_report"
+    }
+}

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/CheckSettingsStorage.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/CheckSettingsStorage.kt
@@ -1,0 +1,17 @@
+package com.spymag.ainewsmakerfetcher
+
+import java.time.LocalDate
+
+interface CheckSettingsStorage {
+    fun getIntervalDays(): Int
+    fun setIntervalDays(days: Int)
+
+    fun getLastSnapshotDate(): LocalDate?
+    fun setLastSnapshotDate(date: LocalDate)
+
+    fun getItemFrequencies(): Map<String, Int>
+    fun setItemFrequencies(frequencies: Map<String, Int>)
+
+    fun getLastShoppingReport(): ShoppingListReport?
+    fun setLastShoppingReport(report: ShoppingListReport?)
+}

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/InventoryCheckConstants.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/InventoryCheckConstants.kt
@@ -1,0 +1,4 @@
+package com.spymag.ainewsmakerfetcher
+
+const val MIN_CHECK_INTERVAL_DAYS = 7
+const val MAX_CHECK_INTERVAL_DAYS = 30

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/InventoryCheckManager.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/InventoryCheckManager.kt
@@ -1,0 +1,68 @@
+package com.spymag.ainewsmakerfetcher
+
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class InventoryCheckManager(
+    private val storage: CheckSettingsStorage
+) {
+
+    fun currentInterval(): Int = storage.getIntervalDays().coerceIn(MIN_CHECK_INTERVAL_DAYS, MAX_CHECK_INTERVAL_DAYS)
+
+    fun updateInterval(days: Int) {
+        storage.setIntervalDays(days.coerceIn(MIN_CHECK_INTERVAL_DAYS, MAX_CHECK_INTERVAL_DAYS))
+    }
+
+    fun nextCheckDate(): LocalDate? {
+        val last = storage.getLastSnapshotDate() ?: return null
+        return last.plusDays(currentInterval().toLong())
+    }
+
+    fun lastReport(): ShoppingListReport? = storage.getLastShoppingReport()
+
+    fun registerSnapshot(snapshot: InventorySnapshot): ShoppingListReport? {
+        val normalizedItems = snapshot.items.mapNotNull { normalizeItem(it) }.toSet()
+        val previousFrequencies = storage.getItemFrequencies()
+        val lastSnapshotDate = storage.getLastSnapshotDate()
+        val interval = currentInterval()
+
+        val shouldEvaluate = lastSnapshotDate?.let {
+            ChronoUnit.DAYS.between(it, snapshot.date) >= interval
+        } ?: false
+
+        val missingCommonItems = if (shouldEvaluate && previousFrequencies.isNotEmpty()) {
+            val commonItems = findMostCommonItems(previousFrequencies)
+            commonItems.filterNot { normalizedItems.contains(it) }
+        } else {
+            emptyList()
+        }
+
+        val updatedFrequencies = previousFrequencies.toMutableMap()
+        normalizedItems.forEach { item ->
+            updatedFrequencies[item] = updatedFrequencies.getOrDefault(item, 0) + 1
+        }
+        storage.setItemFrequencies(updatedFrequencies)
+        storage.setLastSnapshotDate(snapshot.date)
+
+        return if (missingCommonItems.isNotEmpty()) {
+            val report = ShoppingListReport(snapshot.date, missingCommonItems, interval)
+            storage.setLastShoppingReport(report)
+            report
+        } else {
+            null
+        }
+    }
+
+    private fun normalizeItem(raw: String): String? {
+        val trimmed = raw.trim()
+        if (trimmed.isEmpty()) return null
+        return trimmed.lowercase(Locale.getDefault())
+    }
+
+    private fun findMostCommonItems(frequencies: Map<String, Int>): List<String> {
+        if (frequencies.isEmpty()) return emptyList()
+        val maxCount = frequencies.values.maxOrNull() ?: return emptyList()
+        return frequencies.filterValues { it == maxCount }.keys.toList()
+    }
+}

--- a/app/src/main/java/com/spymag/ainewsmakerfetcher/InventoryCheckModels.kt
+++ b/app/src/main/java/com/spymag/ainewsmakerfetcher/InventoryCheckModels.kt
@@ -1,0 +1,20 @@
+package com.spymag.ainewsmakerfetcher
+
+import java.time.LocalDate
+
+/**
+ * Snapshot of detected pantry or inventory items captured on a given [date].
+ */
+data class InventorySnapshot(
+    val date: LocalDate,
+    val items: List<String>
+)
+
+/**
+ * Recommendation generated when common items are missing from a snapshot.
+ */
+data class ShoppingListReport(
+    val generatedOn: LocalDate,
+    val missingItems: List<String>,
+    val intervalDays: Int
+)

--- a/app/src/main/res/layout/fragment_actions.xml
+++ b/app/src/main/res/layout/fragment_actions.xml
@@ -9,6 +9,80 @@
     android:paddingBottom="16dp"
     android:background="?android:colorBackground">
 
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardInventoryChecks"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:padding="16dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="2dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tvCheckIntervalTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/check_interval_title"
+                android:textAppearance="@style/TextAppearance.Material3.TitleMedium" />
+
+            <TextView
+                android:id="@+id/tvCheckIntervalDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/check_interval_description"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
+
+            <TextView
+                android:id="@+id/tvCheckIntervalValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/check_interval_value"
+                android:textAppearance="@style/TextAppearance.Material3.BodyLarge" />
+
+            <com.google.android.material.slider.Slider
+                android:id="@+id/sliderCheckInterval"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:contentDescription="@string/check_interval_slider_content_description"
+                android:valueFrom="7"
+                android:valueTo="30"
+                android:stepSize="1" />
+
+            <TextView
+                android:id="@+id/tvCheckIntervalHint"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/check_interval_hint"
+                android:textAppearance="@style/TextAppearance.Material3.BodySmall" />
+
+            <TextView
+                android:id="@+id/tvNextCheckDate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="@string/check_next_date_unknown"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
+
+            <TextView
+                android:id="@+id/tvLastShoppingReport"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/shopping_report_none"
+                android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,14 @@
     <string name="stop">Stop</string>
     <string name="tab_reports">AI News</string>
     <string name="tab_actions">Actions for today</string>
+    <string name="check_interval_title">Inventory check interval</string>
+    <string name="check_interval_description">We monitor your recurring staples every time you snap a pantry photo.</string>
+    <string name="check_interval_value">Every %1$d days</string>
+    <string name="check_interval_hint">Choose between 7 and 30 days.</string>
+    <string name="check_interval_slider_content_description">Select how many days should pass between pantry checks.</string>
+    <string name="check_next_date_value">Next check after %1$s</string>
+    <string name="check_next_date_unknown">Take a pantry photo to start tracking.</string>
+    <string name="shopping_report_none">No missing common items yet.</string>
+    <string name="shopping_report_message">On %1$s we noticed you were out of: %2$s</string>
+    <string name="shopping_report_toast">Missing staples: %1$s</string>
 </resources>

--- a/app/src/test/java/com/spymag/ainewsmakerfetcher/InventoryCheckManagerTest.kt
+++ b/app/src/test/java/com/spymag/ainewsmakerfetcher/InventoryCheckManagerTest.kt
@@ -1,0 +1,120 @@
+package com.spymag.ainewsmakerfetcher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class InventoryCheckManagerTest {
+
+    private class FakeCheckSettingsStorage : CheckSettingsStorage {
+        var interval = MIN_CHECK_INTERVAL_DAYS
+        var lastSnapshotDate: LocalDate? = null
+        var frequencies: MutableMap<String, Int> = mutableMapOf()
+        var lastReport: ShoppingListReport? = null
+
+        override fun getIntervalDays(): Int = interval
+
+        override fun setIntervalDays(days: Int) {
+            interval = days
+        }
+
+        override fun getLastSnapshotDate(): LocalDate? = lastSnapshotDate
+
+        override fun setLastSnapshotDate(date: LocalDate) {
+            lastSnapshotDate = date
+        }
+
+        override fun getItemFrequencies(): Map<String, Int> = frequencies.toMap()
+
+        override fun setItemFrequencies(frequencies: Map<String, Int>) {
+            this.frequencies = frequencies.toMutableMap()
+        }
+
+        override fun getLastShoppingReport(): ShoppingListReport? = lastReport
+
+        override fun setLastShoppingReport(report: ShoppingListReport?) {
+            lastReport = report
+        }
+    }
+
+    @Test
+    fun updateInterval_clampsValuesToBounds() {
+        val storage = FakeCheckSettingsStorage()
+        val manager = InventoryCheckManager(storage)
+
+        manager.updateInterval(3)
+        assertEquals(MIN_CHECK_INTERVAL_DAYS, storage.interval)
+
+        manager.updateInterval(14)
+        assertEquals(14, storage.interval)
+
+        manager.updateInterval(60)
+        assertEquals(MAX_CHECK_INTERVAL_DAYS, storage.interval)
+    }
+
+    @Test
+    fun registerSnapshot_beforeIntervalDoesNotGenerateReport() {
+        val storage = FakeCheckSettingsStorage()
+        val manager = InventoryCheckManager(storage)
+
+        val first = InventorySnapshot(LocalDate.of(2024, 1, 1), listOf("Milk", "Eggs"))
+        val second = InventorySnapshot(LocalDate.of(2024, 1, 4), listOf("Milk"))
+
+        assertNull(manager.registerSnapshot(first))
+        assertNull(manager.registerSnapshot(second))
+        assertEquals(LocalDate.of(2024, 1, 4), storage.lastSnapshotDate)
+        assertEquals(2, storage.frequencies["milk"])
+        assertEquals(1, storage.frequencies["eggs"])
+        assertNull(storage.lastReport)
+    }
+
+    @Test
+    fun registerSnapshot_afterIntervalWithMissingCommonItemsGeneratesReport() {
+        val storage = FakeCheckSettingsStorage()
+        val manager = InventoryCheckManager(storage)
+
+        val first = InventorySnapshot(LocalDate.of(2024, 1, 1), listOf("Milk", "Eggs"))
+        val second = InventorySnapshot(LocalDate.of(2024, 1, 5), listOf("Milk", "Eggs"))
+        val third = InventorySnapshot(LocalDate.of(2024, 1, 13), listOf("Milk"))
+
+        assertNull(manager.registerSnapshot(first))
+        assertNull(manager.registerSnapshot(second))
+        val report = manager.registerSnapshot(third)
+        assertNotNull(report)
+        assertTrue(report!!.missingItems.contains("eggs"))
+        assertEquals(LocalDate.of(2024, 1, 13), report.generatedOn)
+        assertEquals(MIN_CHECK_INTERVAL_DAYS, report.intervalDays)
+        assertEquals(report, storage.lastReport)
+    }
+
+    @Test
+    fun registerSnapshot_normalizesItemNames() {
+        val storage = FakeCheckSettingsStorage()
+        val manager = InventoryCheckManager(storage)
+
+        val first = InventorySnapshot(LocalDate.of(2024, 1, 1), listOf("  Milk  ", "Eggs"))
+        val second = InventorySnapshot(LocalDate.of(2024, 1, 9), listOf("eggs"))
+
+        manager.registerSnapshot(first)
+        val report = manager.registerSnapshot(second)
+
+        assertNotNull(report)
+        assertTrue(report!!.missingItems.contains("milk"))
+    }
+
+    @Test
+    fun nextCheckDateReflectsLastSnapshotAndInterval() {
+        val storage = FakeCheckSettingsStorage()
+        val manager = InventoryCheckManager(storage)
+
+        val first = InventorySnapshot(LocalDate.of(2024, 1, 1), listOf("Milk"))
+        manager.registerSnapshot(first)
+        assertEquals(LocalDate.of(2024, 1, 8), manager.nextCheckDate())
+
+        manager.updateInterval(10)
+        assertEquals(LocalDate.of(2024, 1, 11), manager.nextCheckDate())
+    }
+}


### PR DESCRIPTION
## Summary
- add shared storage and manager for configurable inventory check intervals with 7-30 day bounds
- extend the Actions tab with an interval slider, next-check messaging, and shopping suggestion surface
- add unit coverage for detecting missing common items and computing next check dates

## Testing
- `./gradlew test` *(fails: SDK location not found in this environment)*

I have read and followed the instructions in AGENTS.md.

------
https://chatgpt.com/codex/tasks/task_b_68c9d7e791008324b344f71587cf92f8